### PR TITLE
Small changes to make compilable on non-Windows OS

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -3,8 +3,13 @@
 #include <ctype.h>
 #include <math.h>
 #include <unistd.h>
+#include <FreeImage.h>
+#ifdef _WIN32
 #include <windows.h>
-#include <freeimage.h>
+#else
+#include <limits.h>
+#define MAX_PATH PATH_MAX
+#endif
 
 #include "tim.h"
 

--- a/main.cpp
+++ b/main.cpp
@@ -3,13 +3,13 @@
 #include <ctype.h>
 #include <math.h>
 #include <unistd.h>
-#include <FreeImage.h>
 #ifdef _WIN32
 #include <windows.h>
 #else
 #include <limits.h>
 #define MAX_PATH PATH_MAX
 #endif
+#include <FreeImage.h>
 
 #include "tim.h"
 

--- a/tim.h
+++ b/tim.h
@@ -2,7 +2,9 @@
 #define _TIM_H
 
 #include <stdio.h>
+#ifdef _WIN32
 #include <windows.h>
+#endif
 #include <math.h>
 
 #define TIM_OUTPUT_CLUT4	0


### PR DESCRIPTION
FreeImage.h filename case correction and windows.h dependency removal.

#ifdef _WIN32 macro valid for both x86 and x64 as per [MSDN](https://docs.microsoft.com/en-us/cpp/preprocessor/predefined-macros?redirectedfrom=MSDN&view=vs-2019) 

Tested on Raspbian armv7l GNU/Linux / CodeBlocks 17.12