### PR TITLE
Support BSD/UNIX compilation targets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,10 @@
 *.bmp
 obj
 gh-pages
+.idea
+cmake-build-debug
+CMakeFiles
+cmake_install.cmake
+CMakeCache.txt
+Makefile
+Img2TIM

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,5 +19,6 @@ add_executable(Img2TIM "main.cpp" "tim.cpp")
 target_include_directories(Img2TIM PRIVATE "tim.h")
 
 # FreeImage
-find_package(freeimage CONFIG REQUIRED)
-target_link_libraries(Img2TIM PRIVATE freeimage::FreeImage freeimage::FreeImagePlus)
+# find_package(FreeImage CONFIG REQUIRED)
+pkg_check_modules(FreeImage REQUIRED IMPORTED_TARGET GLOBAL freeimage)
+target_link_libraries(Img2TIM PRIVATE PkgConfig::FreeImage)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,23 @@
+cmake_minimum_required(VERSION 3.10)
+
+project(Img2TIM VERSION 1.0)
+
+# Debug
+#set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsanitize=address -g -O1")
+
+# C++ standard
+set(CMAKE_CXX_STANDARD 20)
+set(CXXFLAGS "${CMAKE_CXX_FLAGS} -Wall -std=c++20")
+set(CMAKE_CXX_STANDARD_REQUIRED True)
+set(CMAKE_VERBOSE_MAKEFILE ON)
+
+# PkgConfig
+find_package(PkgConfig REQUIRED)
+
+# Mark executable
+add_executable(Img2TIM "main.cpp" "tim.cpp")
+target_include_directories(Img2TIM PRIVATE "tim.h")
+
+# FreeImage
+find_package(freeimage CONFIG REQUIRED)
+target_link_libraries(Img2TIM PRIVATE freeimage::FreeImage freeimage::FreeImagePlus)

--- a/README.md
+++ b/README.md
@@ -16,6 +16,27 @@ The latest precompiled Win32 binary of this program can be downloaded here:
 Previous versions:
 [img2tim_(v0.60).zip](http://lameguy64.github.io/img2tim/img2tim_(v0.60).zip)
 
+## Compiling
+
+This project relies on `PkgConfig` to resolve the necessary dependencies. Esnure that
+it is present on your system and the `freeimage` library is installed.
+
+To initialise the project, run:
+```shell
+cmake -B ./build .
+```
+
+If need be you can directly specify the toolchain if you are using vcpkg:
+
+```shell
+cmake -DCMAKE_TOOLCHAIN_FILE=<path to vcpkg>/vcpkg/scripts/buildsystems/vcpkg.cmake -B ./build .
+```
+
+Then run the program via:
+```shell
+./build/Img2TIM <args>
+```
+
 ## Changelog
 **Version 0.75**
 * Fixed a bug where a false error message is thrown when converting 4-bit images with -bpp 4.

--- a/freeimage.pc
+++ b/freeimage.pc
@@ -1,0 +1,10 @@
+prefix=/opt/homebrew/Cellar/freeimage/3.18.0
+exec_prefix=${prefix}
+includedir=${prefix}/include
+libdir=${exec_prefix}/lib
+
+Name: FreeImage
+Description: FreeImage Library
+Version: 3.18.0
+Cflags: -I${includedir}
+Libs: -L${libdir} -lfreeimage

--- a/tim.h
+++ b/tim.h
@@ -6,6 +6,9 @@
 #include <windows.h>
 #endif
 #include <math.h>
+#if defined(__APPLE__) || defined(linux)
+#include <sys/types.h>
+#endif
 
 #define TIM_OUTPUT_CLUT4	0
 #define TIM_OUTPUT_CLUT8	1


### PR DESCRIPTION
Currently, we expect type definitions to be present through `windows.h` for windows, however on BSD/UNIX systems, they are not available from here. Neither will they be visible through `math.h` or `stdio.h`.

To support BSD/UNIX systems, a simple switch is introduced to allow for inclusion of `sys/types.h`. Additionally, a CMake target is supplied for ease of building using `PkgConfig` to resolve dependencies.